### PR TITLE
Fix position of cuepoints in IE

### DIFF
--- a/cuepoints.html
+++ b/cuepoints.html
@@ -1,1 +1,1 @@
-<vg-cuepoint ng-repeat="cuepoint in cuepoints.points" ng-click="onCuePointClick(cuepoint)" style="left: {{calcLeft(cuepoint)}}%;"></vg-cuepoint>
+<vg-cuepoint ng-repeat="cuepoint in cuepoints.points" ng-click="onCuepointClick(cuepoint)" ng-style="cuepointStyle(cuepoint)"></vg-cuepoint>

--- a/cuepoints.html
+++ b/cuepoints.html
@@ -1,1 +1,0 @@
-<vg-cuepoint ng-repeat="cuepoint in cuepoints.points" ng-click="onCuepointClick(cuepoint)" ng-style="cuepointStyle(cuepoint)"></vg-cuepoint>

--- a/cuepoints.js
+++ b/cuepoints.js
@@ -21,16 +21,22 @@ angular.module('uk.ac.soton.ecs.videogular.plugins.cuepoints', [])
 						}
 					}
 
-					$scope.calcLeft = function(cuepoint) {
+					var calcLeft = function(cuepoint) {
 						if (API.totalTime === 0) return '-1000';
 
 						var videoLength = API.totalTime / 1000;
 						return (cuepoint.time * 100 / videoLength).toString();
 					};
 
-					$scope.onCuePointClick = function(cuepoint){
+					$scope.onCuepointClick = function(cuepoint){
 						API.seekTime(cuepoint.time);
 					};
+
+					$scope.cuepointStyle = function(cuepoint) {
+						return {
+							left: calcLeft(cuepoint) + '%'
+						};
+					}
 
 					updateTheme($scope.theme);
 				},

--- a/cuepoints.js
+++ b/cuepoints.js
@@ -7,7 +7,9 @@ angular.module('uk.ac.soton.ecs.videogular.plugins.cuepoints', [])
 			return {
 				restrict: 'E',
 				require: '^videogular',
-				templateUrl: 'bower_components/videogular-cuepoints/cuepoints.html',
+				templateUrl: function(element, attrs) {
+					return attrs.templateUrl || 'videogular-cuepoints/cuepoints.html';
+				},
 				scope: {
 					cuepoints: '=vgCuepointsConfig',
 					theme: '=vgCuepointsTheme',
@@ -41,5 +43,10 @@ angular.module('uk.ac.soton.ecs.videogular.plugins.cuepoints', [])
 					updateTheme($scope.theme);
 				},
 			};
-		}]);
+		}])
+	.run(['$templateCache', function($templateCache) {
+		$templateCache.put('videogular-cuepoints/cuepoints.html',
+			'<vg-cuepoint ng-repeat="cuepoint in cuepoints.points" ng-click="onCuepointClick(cuepoint)" ng-style="cuepointStyle(cuepoint)"></vg-cuepoint>'
+		);
+	}]);
 })();


### PR DESCRIPTION
It's commonly known that the style attribute can not be written "inline" in IE. There is a simple fix to assign the whole object with styles created in controller instead of inline calculations.

More info: http://stackoverflow.com/a/26787785/878514 and http://stackoverflow.com/a/25655451/878514

The second saves the default template in th `$templateCache` and allows to specify a custom one.
